### PR TITLE
Reorder technical talks: Add AI Agent Design Patterns video

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,13 +302,13 @@
 										
 
 									<article>
-										<iframe width="100%" aspect-ratio="16/9" src="https://www.youtube.com/embed/roHgcmC_oXg?si=gYtnb6NQXfXoEuc_" title="Travelara Launch Day: Exclusive Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-								
-										<h3>Travelara Launch Day: Exclusive Demo</h3>
-										<p><strong>MongoDB, Express.js, React.js, Node.js</strong> - Platform to help build momentous milestones along with your friends and family! Travelara makes Dream Trips a Reality!</p>
+										<iframe width="100%" aspect-ratio="16/9" src="https://www.youtube.com/embed/ANDJZycMGrg?si=rQvqDHQLhuS40uWw" title="AI Agent Design Patterns" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+										<br>
+										<br>
+										<h3>AI Agent Design Patterns</h3>
+										<p><strong>Flowise, AI Agents</strong> - Breaks down four core agent design patterns: Single Agent + Tools (RAG), Sequential Agents, Parallel Agents, and Human-in-the-Loop. Production systems typically combine patterns based on complexity, speed, and risk tolerance.</p>
 										<ul class="actions">
-											<li><a target="_blank" href="https://github.com/CharlesCreativeContent/Demo-Day" class="button">Code Repo</a></li>
-											<li><a target="_blank" href="https://youtube.com/watch?v=roHgcmC_oXg" class="button">Watch Video</a></li>
+											<li><a target="_blank" href="https://www.youtube.com/watch?v=ANDJZycMGrg" class="button">Watch Video</a></li>
 										</ul>
 									</article>
 

--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
 									</header>
 									<div class="posts">
 
+
 								<article>
 									<a target="_blank" href="https://github.com/CharlesCreativeContent/runware-pokemon-generator" class="image">
 										<img src="https://github.com/CharlesCreativeContent/runware-pokemon-generator/raw/main/public/runware.gif?raw=true" alt="GenUI with C1" />
@@ -247,6 +248,17 @@
 										<h2 >Technical Talks & Videos</h2>
 									</header>
 									<div class="posts">
+										<article>
+										<iframe width="100%" aspect-ratio="16/9" src="https://www.youtube.com/embed/ANDJZycMGrg?si=rQvqDHQLhuS40uWw" title="AI Agent Design Patterns" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+										<br>
+										<br>
+										<h3>AI Agent Design Patterns</h3>
+										<p><strong>Flowise, AI Agents</strong> - Breaks down four core agent design patterns: Single Agent + Tools (RAG), Sequential Agents, Parallel Agents, and Human-in-the-Loop. Production systems typically combine patterns based on complexity, speed, and risk tolerance.</p>
+										<ul class="actions">
+											<li><a target="_blank" href="https://www.youtube.com/watch?v=ANDJZycMGrg" class="button">Watch Video</a></li>
+										</ul>
+										</article>
+
 										
 										<article>
 										
@@ -295,20 +307,6 @@
 										<ul class="actions">
 											<li><a target="_blank" href="https://github.com/CharlesCreativeContent/elastic-path-demo" class="button">Code Repo</a></li>
 											<li><a target="_blank" href="https://www.youtube.com/watch?v=1dHhMwfqb9w" class="button">Watch Video</a></li>
-										</ul>
-									</article>
-										
-										
-										
-
-									<article>
-										<iframe width="100%" aspect-ratio="16/9" src="https://www.youtube.com/embed/ANDJZycMGrg?si=rQvqDHQLhuS40uWw" title="AI Agent Design Patterns" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-										<br>
-										<br>
-										<h3>AI Agent Design Patterns</h3>
-										<p><strong>Flowise, AI Agents</strong> - Breaks down four core agent design patterns: Single Agent + Tools (RAG), Sequential Agents, Parallel Agents, and Human-in-the-Loop. Production systems typically combine patterns based on complexity, speed, and risk tolerance.</p>
-										<ul class="actions">
-											<li><a target="_blank" href="https://www.youtube.com/watch?v=ANDJZycMGrg" class="button">Watch Video</a></li>
 										</ul>
 									</article>
 


### PR DESCRIPTION
## Summary
Updated the Technical Talks & Videos section by adding a new featured video on AI Agent Design Patterns and reordering the video list.

## Key Changes
- Added new article featuring "AI Agent Design Patterns" video from Flowise, positioned as the first/featured talk
  - Includes embedded YouTube iframe
  - Provides description of core agent design patterns covered
  - Links to full video on YouTube
- Removed the "Travelara Launch Day: Exclusive Demo" video article from the technical talks section
- Minor whitespace adjustments in the posts section

## Implementation Details
- The new AI Agent Design Patterns video is now prominently displayed at the top of the Technical Talks section
- The video description highlights the four core patterns discussed: Single Agent + Tools (RAG), Sequential Agents, Parallel Agents, and Human-in-the-Loop
- Maintained consistent HTML structure and styling with existing video articles

https://claude.ai/code/session_01SWzGK4BbnK5pkYXKm4Vbxi